### PR TITLE
Timeutil update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ gitPublishConfig {
 }
 
 group = "com.github.lordrex34.config"
-version = "1.0.5"
+version = "1.0.6"
 
 repositories {
 	mavenCentral()

--- a/src/main/java/com/github/lordrex34/config/converter/DurationConfigConverter.java
+++ b/src/main/java/com/github/lordrex34/config/converter/DurationConfigConverter.java
@@ -22,6 +22,7 @@
 package com.github.lordrex34.config.converter;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
 
 import com.github.lordrex34.config.util.TimeUtil;
 
@@ -39,7 +40,7 @@ public class DurationConfigConverter implements IConfigConverter
 	@Override
 	public String convertToString(Field field, Class<?> type, Object obj)
 	{
-		return obj.toString();
+		return TimeUtil.durationToString((Duration) obj);
 	}
 	
 	public static final DurationConfigConverter getInstance()

--- a/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
+++ b/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
@@ -271,7 +271,7 @@ public final class TimeUtil
 	/** Clone of java 9 {@code duration.toDaysPart()} to allow support until we update to above java 8. */
 	private static long toDaysPart(Duration duration)
 	{
-		return duration.toSeconds() / 86400;
+		return duration.getSeconds() / 86400;
 	}
 
 	/** Clone of java 9 {@code duration.toHoursPart()} to allow support until we update to above java 8. */

--- a/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
+++ b/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
@@ -37,11 +37,11 @@ public class TimeUtil
 	/**
 	 * Parses patterns like:
 	 * <ul>
+	 * <li>1millis or 10millis</li>
+	 * <li>1sec or 10secs</li>
 	 * <li>1min or 10mins</li>
 	 * <li>1day or 10days</li>
 	 * <li>1week or 4weeks</li>
-	 * <li>1month or 12months</li>
-	 * <li>1year or 5years</li>
 	 * </ul>
 	 * Also multiple value types in pattern are supported as well:
 	 * <ul>
@@ -57,33 +57,36 @@ public class TimeUtil
 	 * <li>millis</li>
 	 * <li>sec</li>
 	 * <li>secs</li>
+	 * <li>second</li>
+	 * <li>seconds</li>
 	 * <li>min</li>
 	 * <li>mins</li>
+	 * <li>minute</li>
+	 * <li>minutes</li>
 	 * <li>hour</li>
 	 * <li>hours</li>
+	 * <li>halfday</li>
+	 * <li>halfdays</li>
 	 * <li>day</li>
 	 * <li>days</li>
 	 * <li>week</li>
 	 * <li>weeks</li>
-	 * <li>month</li>
-	 * <li>months</li>
-	 * <li>year</li>
-	 * <li>years</li>
-	 * <li>All enum names of {@link ChronoUnit} by auto-converting input time unit to upper case before matching.</li>
 	 * </ul>
-	 * @param datePattern
+	 * Values such as months or years and everything above are not supported, because they are estimate values instead of precise ones.<br>
+	 * For example, one month can either be 30 or 31 days or one year can either be 365 or 366 days. A decade consists of 10 years with estimated amount of days.
+	 * @param pattern the pattern of duration to be parsed.
 	 * @return {@link Duration} object converted by the date pattern specified.
 	 * @throws IllegalStateException when malformed pattern specified.
 	 */
-	public static Duration parseDuration(String datePattern)
+	public static Duration parseDuration(String pattern)
 	{
 		try
 		{
 			Duration result = null;
-			final Matcher matcher = PARSE_DURATION_PATTERN.matcher(datePattern);
+			final Matcher matcher = PARSE_DURATION_PATTERN.matcher(pattern);
 			while (matcher.find())
 			{
-				final long value = Long.parseLong(matcher.group(1));
+				long value = Long.parseLong(matcher.group(1));
 				final String type = matcher.group(2);
 				final ChronoUnit unit;
 				switch (type.toLowerCase())
@@ -105,12 +108,16 @@ public class TimeUtil
 					}
 					case "sec":
 					case "secs":
+					case "second":
+					case "seconds":
 					{
 						unit = ChronoUnit.SECONDS;
 						break;
 					}
 					case "min":
 					case "mins":
+					case "minutes":
+					case "minute":
 					{
 						unit = ChronoUnit.MINUTES;
 						break;
@@ -119,6 +126,12 @@ public class TimeUtil
 					case "hours":
 					{
 						unit = ChronoUnit.HOURS;
+						break;
+					}
+					case "halfday":
+					case "halfdays":
+					{
+						unit = ChronoUnit.HALF_DAYS;
 						break;
 					}
 					case "day":
@@ -130,28 +143,13 @@ public class TimeUtil
 					case "week":
 					case "weeks":
 					{
-						unit = ChronoUnit.WEEKS;
-						break;
-					}
-					case "month":
-					case "months":
-					{
-						unit = ChronoUnit.MONTHS;
-						break;
-					}
-					case "year":
-					case "years":
-					{
-						unit = ChronoUnit.YEARS;
+						value *= ChronoUnit.WEEKS.getDuration().toDays();
+						unit = ChronoUnit.DAYS;
 						break;
 					}
 					default:
 					{
-						unit = ChronoUnit.valueOf(type.toUpperCase());
-						if (unit == null)
-						{
-							throw new IllegalArgumentException("Incorrect unit of time: " + type + "!");
-						}
+						throw new IllegalArgumentException("Incorrect or unsupported time unit type: " + type);
 					}
 				}
 
@@ -167,7 +165,7 @@ public class TimeUtil
 		}
 		catch (Exception e)
 		{
-			throw new IllegalStateException("Incorrect time format given: " + datePattern + "!", e);
+			throw new IllegalStateException("Incorrect time format given: " + pattern + "!", e);
 		}
 	}
 }

--- a/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
+++ b/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
@@ -31,12 +31,19 @@ import java.util.regex.Pattern;
 /**
  * @author Nik
  */
-public class TimeUtil
+public final class TimeUtil
 {
 	private static class Lazy
 	{
-		/** Pattern that matches texts similar to "1hour30min20sec" into multiple groups of digit and non-digit parts. */
+		/**
+		 * Pattern that matches texts similar to "1hour30min20sec" into multiple groups of digit and non-digit parts.
+		 */
 		static final Pattern PARSE_DURATION_PATTERN = Pattern.compile("(\\d+)([^\\d]+)");
+	}
+
+	private TimeUtil()
+	{
+		// Utility class
 	}
 
 	/**

--- a/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
+++ b/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
@@ -23,24 +23,16 @@ package com.github.lordrex34.config.util;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * @author UnAfraid
+ * @author UnAfraid, Nik
  */
 public class TimeUtil
 {
-	public static int findIndexOfNonDigit(CharSequence text)
-	{
-		for (int i = 0; i < text.length(); i++)
-		{
-			if (Character.isDigit(text.charAt(i)))
-			{
-				continue;
-			}
-			return i;
-		}
-		return -1;
-	}
+	/** Pattern that matches texts similar to "1hour30min20sec" into multiple groups of digit and non-digit parts. */
+	public static final Pattern PARSE_DURATION_PATTERN = Pattern.compile("(\\d+)([^\\d]+)");
 	
 	/**
 	 * Parses patterns like:
@@ -51,80 +43,131 @@ public class TimeUtil
 	 * <li>1month or 12months</li>
 	 * <li>1year or 5years</li>
 	 * </ul>
+	 * Also multiple value types in pattern are supported as well:
+	 * <ul>
+	 * <li>1hour30min20sec</li>
+	 * <li>3days22hours20mins</li>
+	 * <li>1week5days6hours</li>
+	 * <li>10hours20mins30secs500millis200micros100nanos</li>
+	 * </ul>
+	 * Supported time units:
+	 * <ul>
+	 * <li>nanos</li>
+	 * <li>micros</li>
+	 * <li>millis</li>
+	 * <li>sec</li>
+	 * <li>secs</li>
+	 * <li>min</li>
+	 * <li>mins</li>
+	 * <li>hour</li>
+	 * <li>hours</li>
+	 * <li>day</li>
+	 * <li>days</li>
+	 * <li>week</li>
+	 * <li>weeks</li>
+	 * <li>month</li>
+	 * <li>months</li>
+	 * <li>year</li>
+	 * <li>years</li>
+	 * <li>All enum names of {@link ChronoUnit} by auto-converting input time unit to upper case before matching.</li>
+	 * </ul>
 	 * @param datePattern
 	 * @return {@link Duration} object converted by the date pattern specified.
 	 * @throws IllegalStateException when malformed pattern specified.
 	 */
 	public static Duration parseDuration(String datePattern)
 	{
-		final int index = findIndexOfNonDigit(datePattern);
-		if (index == -1)
-		{
-			throw new IllegalStateException("Incorrect time format given: " + datePattern);
-		}
 		try
 		{
-			int val = Integer.parseInt(datePattern.substring(0, index));
-			final String type = datePattern.substring(index);
-			final ChronoUnit unit;
-			switch (type.toLowerCase())
+			Duration result = null;
+			final Matcher matcher = PARSE_DURATION_PATTERN.matcher(datePattern);
+			while (matcher.find())
 			{
-				case "sec":
-				case "secs":
+				final long value = Long.parseLong(matcher.group(1));
+				final String type = matcher.group(2);
+				final ChronoUnit unit;
+				switch (type.toLowerCase())
 				{
-					unit = ChronoUnit.SECONDS;
-					break;
-				}
-				case "min":
-				case "mins":
-				{
-					unit = ChronoUnit.MINUTES;
-					break;
-				}
-				case "hour":
-				case "hours":
-				{
-					unit = ChronoUnit.HOURS;
-					break;
-				}
-				case "day":
-				case "days":
-				{
-					unit = ChronoUnit.DAYS;
-					break;
-				}
-				case "week":
-				case "weeks":
-				{
-					unit = ChronoUnit.WEEKS;
-					break;
-				}
-				case "month":
-				case "months":
-				{
-					unit = ChronoUnit.MONTHS;
-					break;
-				}
-				case "year":
-				case "years":
-				{
-					unit = ChronoUnit.YEARS;
-					break;
-				}
-				default:
-				{
-					unit = ChronoUnit.valueOf(type);
-					if (unit == null)
+					case "nanos":
 					{
-						throw new IllegalStateException("Incorrect format: " + type + " !!");
+						unit = ChronoUnit.NANOS;
+						break;
+					}
+					case "micros":
+					{
+						unit = ChronoUnit.MICROS;
+						break;
+					}
+					case "millis":
+					{
+						unit = ChronoUnit.MILLIS;
+						break;
+					}
+					case "sec":
+					case "secs":
+					{
+						unit = ChronoUnit.SECONDS;
+						break;
+					}
+					case "min":
+					case "mins":
+					{
+						unit = ChronoUnit.MINUTES;
+						break;
+					}
+					case "hour":
+					case "hours":
+					{
+						unit = ChronoUnit.HOURS;
+						break;
+					}
+					case "day":
+					case "days":
+					{
+						unit = ChronoUnit.DAYS;
+						break;
+					}
+					case "week":
+					case "weeks":
+					{
+						unit = ChronoUnit.WEEKS;
+						break;
+					}
+					case "month":
+					case "months":
+					{
+						unit = ChronoUnit.MONTHS;
+						break;
+					}
+					case "year":
+					case "years":
+					{
+						unit = ChronoUnit.YEARS;
+						break;
+					}
+					default:
+					{
+						unit = ChronoUnit.valueOf(type.toUpperCase());
+						if (unit == null)
+						{
+							throw new IllegalArgumentException("Incorrect unit of time: " + type + "!");
+						}
 					}
 				}
+
+				result = result == null ? Duration.of(value, unit) : result.plus(value, unit);
 			}
-			return Duration.of(val, unit);
+
+			if (result == null)
+			{
+				throw new IllegalStateException("Time format has failed to produce results!");
+			}
+
+			return result;
 		}
 		catch (Exception e)
 		{
-			throw new IllegalStateException("Incorrect time format given: " + datePattern + " val: " + datePattern.substring(0, index));
+			throw new IllegalStateException("Incorrect time format given: " + datePattern + "!", e);
 		}
 	}
 }

--- a/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
+++ b/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
@@ -106,74 +106,7 @@ public final class TimeUtil
 				final Matcher matcher = Lazy.PARSE_DURATION_PATTERN.matcher(pattern);
 				while (matcher.find())
 				{
-					long value = Long.parseLong(matcher.group(1));
-					final String type = matcher.group(2);
-					final ChronoUnit unit;
-					switch (type.toLowerCase())
-					{
-						case "nanos":
-						{
-							unit = ChronoUnit.NANOS;
-							break;
-						}
-						case "micros":
-						{
-							unit = ChronoUnit.MICROS;
-							break;
-						}
-						case "millis":
-						{
-							unit = ChronoUnit.MILLIS;
-							break;
-						}
-						case "sec":
-						case "secs":
-						case "second":
-						case "seconds":
-						{
-							unit = ChronoUnit.SECONDS;
-							break;
-						}
-						case "min":
-						case "mins":
-						case "minutes":
-						case "minute":
-						{
-							unit = ChronoUnit.MINUTES;
-							break;
-						}
-						case "hour":
-						case "hours":
-						{
-							unit = ChronoUnit.HOURS;
-							break;
-						}
-						case "halfday":
-						case "halfdays":
-						{
-							unit = ChronoUnit.HALF_DAYS;
-							break;
-						}
-						case "day":
-						case "days":
-						{
-							unit = ChronoUnit.DAYS;
-							break;
-						}
-						case "week":
-						case "weeks":
-						{
-							value = ChronoUnit.WEEKS.getDuration().multipliedBy(value).toDays();
-							unit = ChronoUnit.DAYS;
-							break;
-						}
-						default:
-						{
-							throw new IllegalArgumentException("Incorrect or unsupported time unit type: " + type);
-						}
-					}
-
-					result = result == null ? Duration.of(value, unit) : result.plus(value, unit);
+					result = parseSingleUnitDuration(matcher, result);
 				}
 
 				if (result == null)
@@ -188,6 +121,84 @@ public final class TimeUtil
 				throw new IllegalStateException("Incorrect time format given: " + pattern + "!", e);
 			}
 		}
+	}
+
+	/**
+	 * Parses a single unit of duration, following the pattern at {@link #parseDuration(String)}
+	 * @param matcher the matcher result of the pattern
+	 * @param durationToAdd the amount of duration to which the result will be added or {@code null} to return result as is.
+	 * @return the resulting duration of the pattern parsing, or the sum of the result with the given duration to add.
+	 */
+	public static Duration parseSingleUnitDuration(Matcher matcher, Duration durationToAdd)
+	{
+		long value = Long.parseLong(matcher.group(1));
+		final String type = matcher.group(2);
+		final ChronoUnit unit;
+		switch (type.toLowerCase())
+		{
+			case "nanos":
+			{
+				unit = ChronoUnit.NANOS;
+				break;
+			}
+			case "micros":
+			{
+				unit = ChronoUnit.MICROS;
+				break;
+			}
+			case "millis":
+			{
+				unit = ChronoUnit.MILLIS;
+				break;
+			}
+			case "sec":
+			case "secs":
+			case "second":
+			case "seconds":
+			{
+				unit = ChronoUnit.SECONDS;
+				break;
+			}
+			case "min":
+			case "mins":
+			case "minutes":
+			case "minute":
+			{
+				unit = ChronoUnit.MINUTES;
+				break;
+			}
+			case "hour":
+			case "hours":
+			{
+				unit = ChronoUnit.HOURS;
+				break;
+			}
+			case "halfday":
+			case "halfdays":
+			{
+				unit = ChronoUnit.HALF_DAYS;
+				break;
+			}
+			case "day":
+			case "days":
+			{
+				unit = ChronoUnit.DAYS;
+				break;
+			}
+			case "week":
+			case "weeks":
+			{
+				value = ChronoUnit.WEEKS.getDuration().multipliedBy(value).toDays();
+				unit = ChronoUnit.DAYS;
+				break;
+			}
+			default:
+			{
+				throw new IllegalArgumentException("Incorrect or unsupported time unit type: " + type);
+			}
+		}
+
+		return durationToAdd == null ? Duration.of(value, unit) : durationToAdd.plus(value, unit);
 	}
 
 	/**
@@ -212,48 +223,78 @@ public final class TimeUtil
 		}
 
 		String result = "";
-		if (duration.toDaysPart() > 1)
+		if (toDaysPart(duration) > 1)
 		{
-			result += duration.toDaysPart() + "days";
+			result += toDaysPart(duration) + "days";
 		}
-		if (duration.toDaysPart() == 1)
+		if (toDaysPart(duration) == 1)
 		{
-			result += duration.toDaysPart() + "day";
+			result += toDaysPart(duration) + "day";
 		}
-		if (duration.toHoursPart() > 1)
+		if (toHoursPart(duration) > 1)
 		{
-			result += duration.toHoursPart() + "hours";
+			result += toHoursPart(duration) + "hours";
 		}
-		if (duration.toHoursPart() == 1)
+		if (toHoursPart(duration) == 1)
 		{
-			result += duration.toHoursPart() + "hour";
+			result += toHoursPart(duration) + "hour";
 		}
-		if (duration.toMinutesPart() > 1)
+		if (toMinutesPart(duration) > 1)
 		{
-			result += duration.toMinutesPart() + "mins";
+			result += toMinutesPart(duration) + "mins";
 		}
-		if (duration.toMinutesPart() == 1)
+		if (toMinutesPart(duration) == 1)
 		{
-			result += duration.toMinutesPart() + "min";
+			result += toMinutesPart(duration) + "min";
 		}
-		if (duration.toSecondsPart() > 1)
+		if (toSecondsPart(duration) > 1)
 		{
-			result += duration.toSecondsPart() + "secs";
+			result += toSecondsPart(duration) + "secs";
 		}
-		if (duration.toSecondsPart() == 1)
+		if (toSecondsPart(duration) == 1)
 		{
-			result += duration.toSecondsPart() + "sec";
+			result += toSecondsPart(duration) + "sec";
 		}
-		if (duration.toMillisPart() >= 1)
+		if (toMillisPart(duration) >= 1)
 		{
-			result += duration.toMillisPart() + "millis";
+			result += toMillisPart(duration) + "millis";
 		}
 		// I don't know why toNanosPart returns nanoseconds unmodified by milliseconds mod.
-		if (duration.toNanosPart() % ChronoUnit.MILLIS.getDuration().getNano() >= 1)
+		if (duration.getNano() % ChronoUnit.MILLIS.getDuration().getNano() >= 1)
 		{
-			result += (duration.toNanosPart() % ChronoUnit.MILLIS.getDuration().getNano()) + "nanos";
+			result += (duration.getNano() % ChronoUnit.MILLIS.getDuration().getNano()) + "nanos";
 		}
 
 		return result;
+	}
+
+	/** Clone of java 9 {@code duration.toDaysPart()} to allow support until we update to above java 8. */
+	private static long toDaysPart(Duration duration)
+	{
+		return duration.toSeconds() / 86400;
+	}
+
+	/** Clone of java 9 {@code duration.toHoursPart()} to allow support until we update to above java 8. */
+	private static int toHoursPart(Duration duration)
+	{
+		return (int) (duration.toHours() % 24);
+	}
+
+	/** Clone of java 9 {@code duration.toMinutesPart()} to allow support until we update to above java 8. */
+	private static int toMinutesPart(Duration duration)
+	{
+		return (int) (duration.toMinutes() % 60);
+	}
+
+	/** Clone of java 9 {@code duration.toSecondsPart()} to allow support until we update to above java 8. */
+	private static int toSecondsPart(Duration duration)
+	{
+		return (int) (duration.getSeconds() % 60);
+	}
+
+	/** Clone of java 9 {@code duration.toMillisPart()} to allow support until we update to above java 8. */
+	private static int toMillisPart(Duration duration)
+	{
+		return duration.getNano() / 1000_000;
 	}
 }

--- a/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
+++ b/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
@@ -163,7 +163,7 @@ public final class TimeUtil
 						case "week":
 						case "weeks":
 						{
-							value *= ChronoUnit.WEEKS.getDuration().toDays();
+							value = ChronoUnit.WEEKS.getDuration().multipliedBy(value).toDays();
 							unit = ChronoUnit.DAYS;
 							break;
 						}

--- a/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
+++ b/src/main/java/com/github/lordrex34/config/util/TimeUtil.java
@@ -24,11 +24,12 @@ package com.github.lordrex34.config.util;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * @author UnAfraid, Nik
+ * @author Nik
  */
 public class TimeUtil
 {
@@ -180,5 +181,72 @@ public class TimeUtil
 				throw new IllegalStateException("Incorrect time format given: " + pattern + "!", e);
 			}
 		}
+	}
+
+	/**
+	 * Converts the given duration to a format that can be parsed by {@link #parseDuration(String)}.<br>
+	 * The util format of duration present in {@link #parseDuration(String)} is preferred over the default {@link Duration#parse(CharSequence)}<br>
+	 * Only negative duration values will be converted to the default {@link Duration#parse(CharSequence)} pattern.
+	 * @param duration the duration which will be converted to string.
+	 * @return a string representation of the given duration, which can then be used to recreate the same duration via {@link #parseDuration(String)}
+	 */
+	public static String durationToString(Duration duration)
+	{
+		Objects.requireNonNull(duration);
+
+		if (duration.isNegative())
+		{
+			return duration.toString();
+		}
+
+		if (duration.isZero())
+		{
+			return "0secs";
+		}
+
+		String result = "";
+		if (duration.toDaysPart() > 1)
+		{
+			result += duration.toDaysPart() + "days";
+		}
+		if (duration.toDaysPart() == 1)
+		{
+			result += duration.toDaysPart() + "day";
+		}
+		if (duration.toHoursPart() > 1)
+		{
+			result += duration.toHoursPart() + "hours";
+		}
+		if (duration.toHoursPart() == 1)
+		{
+			result += duration.toHoursPart() + "hour";
+		}
+		if (duration.toMinutesPart() > 1)
+		{
+			result += duration.toMinutesPart() + "mins";
+		}
+		if (duration.toMinutesPart() == 1)
+		{
+			result += duration.toMinutesPart() + "min";
+		}
+		if (duration.toSecondsPart() > 1)
+		{
+			result += duration.toSecondsPart() + "secs";
+		}
+		if (duration.toSecondsPart() == 1)
+		{
+			result += duration.toSecondsPart() + "sec";
+		}
+		if (duration.toMillisPart() >= 1)
+		{
+			result += duration.toMillisPart() + "millis";
+		}
+		// I don't know why toNanosPart returns nanoseconds unmodified by milliseconds mod.
+		if (duration.toNanosPart() % ChronoUnit.MILLIS.getDuration().getNano() >= 1)
+		{
+			result += (duration.toNanosPart() % ChronoUnit.MILLIS.getDuration().getNano()) + "nanos";
+		}
+
+		return result;
 	}
 }

--- a/src/test/java/com/github/lordrex34/config/TestConfigDuration.java
+++ b/src/test/java/com/github/lordrex34/config/TestConfigDuration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Reginald Ravenhorst <lordrex34@gmail.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lordrex34.config;
+
+import static org.junit.Assert.*;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+import com.github.lordrex34.config.annotation.ConfigClass;
+import com.github.lordrex34.config.annotation.ConfigField;
+
+/**
+ * @author lord_rex
+ */
+public class TestConfigDuration extends AbstractConfigTest
+{
+	@Test
+	public void test()
+	{
+		assertNotEquals(_configManager.getConfigRegistrySize(), 0);
+		assertEquals(ConfigDurationTest.TEST_DURATION, Duration.ofSeconds(20));
+	}
+	
+	@ConfigClass(fileName = "test_duration")
+	public static class ConfigDurationTest
+	{
+		public static final String TWENTY_SECS = "20secs";
+		
+		@ConfigField(name = "TestDuration", value = TWENTY_SECS)
+		public static Duration TEST_DURATION;
+	}
+}

--- a/src/test/java/com/github/lordrex34/config/TestTimeUtil.java
+++ b/src/test/java/com/github/lordrex34/config/TestTimeUtil.java
@@ -21,26 +21,19 @@
  */
 package com.github.lordrex34.config;
 
-import com.github.lordrex34.config.annotation.ConfigClass;
-import com.github.lordrex34.config.annotation.ConfigField;
 import com.github.lordrex34.config.util.TimeUtil;
 import org.junit.Test;
 
 import java.time.Duration;
-import java.time.Period;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Nik

--- a/src/test/java/com/github/lordrex34/config/TestTimeUtil.java
+++ b/src/test/java/com/github/lordrex34/config/TestTimeUtil.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2017 Reginald Ravenhorst <lordrex34@gmail.com>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lordrex34.config;
+
+import com.github.lordrex34.config.annotation.ConfigClass;
+import com.github.lordrex34.config.annotation.ConfigField;
+import com.github.lordrex34.config.util.TimeUtil;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Nik
+ */
+public class TestTimeUtil extends AbstractConfigTest
+{
+	private static final Map<String, Duration> TEST_VALUES = new HashMap<>();
+	private static final Set<String> TEST_EXCEPTIONS = new HashSet<>();
+	static
+	{
+		TEST_VALUES.put("10nanos", Duration.of(10, ChronoUnit.NANOS));
+		TEST_VALUES.put("10micros", Duration.of(10, ChronoUnit.MICROS));
+		TEST_VALUES.put("10millis", Duration.ofMillis(10));
+		TEST_VALUES.put("1sec", Duration.ofSeconds(1));
+		TEST_VALUES.put("10secs", Duration.ofSeconds(10));
+		TEST_VALUES.put("1second", Duration.ofSeconds(1));
+		TEST_VALUES.put("10seconds", Duration.ofSeconds(10));
+		TEST_VALUES.put("1min", Duration.ofMinutes(1));
+		TEST_VALUES.put("10mins", Duration.ofMinutes(10));
+		TEST_VALUES.put("1minute", Duration.ofMinutes(1));
+		TEST_VALUES.put("10minutes", Duration.ofMinutes(10));
+		TEST_VALUES.put("1hour", Duration.ofHours(1));
+		TEST_VALUES.put("10hours", Duration.ofHours(10));
+		TEST_VALUES.put("1halfday", Duration.of(1, ChronoUnit.HALF_DAYS));
+		TEST_VALUES.put("10halfdays", Duration.of(10, ChronoUnit.HALF_DAYS));
+		TEST_VALUES.put("1day", Duration.ofDays(1));
+		TEST_VALUES.put("10days", Duration.ofDays(10));
+		TEST_VALUES.put("1week", ChronoUnit.WEEKS.getDuration());
+		TEST_VALUES.put("2weeks", ChronoUnit.WEEKS.getDuration().plus(ChronoUnit.WEEKS.getDuration()));
+
+		// Now the trickier ones:
+
+		// Create a megapattern from all previous single-type ones.
+		TEST_VALUES.put(TEST_VALUES.keySet().stream().collect(Collectors.joining()), TEST_VALUES.values().stream().reduce(Duration.ZERO, Duration::plus));
+
+		// Create forever representation of duration.
+		TEST_VALUES.put("9223372036854775807secs999999999nanos", ChronoUnit.FOREVER.getDuration());
+
+		// Create zero representation of duration.
+		TEST_VALUES.put("0nanos", Duration.ZERO);
+		TEST_VALUES.put("0micros", Duration.ZERO);
+		TEST_VALUES.put("0millis", Duration.ZERO);
+		TEST_VALUES.put("0secs", Duration.ZERO);
+		TEST_VALUES.put("0mins", Duration.ZERO);
+		TEST_VALUES.put("0hours", Duration.ZERO);
+		TEST_VALUES.put("0halfdays", Duration.ZERO);
+		TEST_VALUES.put("0days", Duration.ZERO);
+		TEST_VALUES.put("0weeks", Duration.ZERO);
+
+		// Create custom multi-type pattern.
+		TEST_VALUES.put("10hours5minutes", Duration.ofHours(10).plusMinutes(5));
+		TEST_VALUES.put("10hours5minutes3seconds", Duration.ofHours(10).plusMinutes(5).plusSeconds(3));
+		TEST_VALUES.put("10hours5minutes3seconds500millis", Duration.ofHours(10).plusMinutes(5).plusSeconds(3).plusMillis(500));
+		TEST_VALUES.put("8days3hours7minutes2seconds333millis", Duration.ofDays(8).plusHours(3).plusMinutes(7).plusSeconds(2).plusMillis(333));
+		TEST_VALUES.put("10weeks8days3hours7minutes2seconds333millis", Duration.ofDays((10 * 7) + 8).plusHours(3).plusMinutes(7).plusSeconds(2).plusMillis(333));
+
+		// Create reverse order (should still work)
+		TEST_VALUES.put("333millis2seconds7minutes3hours8days10weeks", Duration.ofDays((10 * 7) + 8).plusHours(3).plusMinutes(7).plusSeconds(2).plusMillis(333));
+
+		// Create random order (should still work)
+		TEST_VALUES.put("2seconds8days333millis7minutes10weeks3hours", Duration.ofDays((10 * 7) + 8).plusHours(3).plusMinutes(7).plusSeconds(2).plusMillis(333));
+
+		TEST_EXCEPTIONS.add("-10minutes");
+		TEST_EXCEPTIONS.add("10minutes-5seconds");
+		TEST_EXCEPTIONS.add("gdbvflordrexnubfasdf");
+		TEST_EXCEPTIONS.add("10hourss");
+		TEST_EXCEPTIONS.add("5milis");
+		TEST_EXCEPTIONS.add("10000000000weeks");
+		TEST_EXCEPTIONS.add("10000000000days");
+		TEST_EXCEPTIONS.add("10000000000000000000000000000000000000000000000000nanos");
+		TEST_EXCEPTIONS.add("10");
+		TEST_EXCEPTIONS.add("secs");
+	}
+
+	@Test
+	public void test()
+	{
+		assertFalse(TEST_VALUES.isEmpty());
+
+		for (Map.Entry<String, Duration> entry : TEST_VALUES.entrySet())
+		{
+			final String pattern = entry.getKey();
+			final Duration result = TimeUtil.parseDuration(pattern);
+			final Duration expectedResult = entry.getValue();
+
+			assertEquals("Failed to parse " + pattern, result, expectedResult);
+		}
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testExceptions()
+	{
+		for (String pattern : TEST_EXCEPTIONS)
+		{
+			TimeUtil.parseDuration(pattern);
+		}
+	}
+	
+}

--- a/src/test/java/com/github/lordrex34/config/TestTimeUtil.java
+++ b/src/test/java/com/github/lordrex34/config/TestTimeUtil.java
@@ -121,6 +121,12 @@ public class TestTimeUtil extends AbstractConfigTest
 
 			assertEquals("Failed to parse " + pattern, result, expectedResult);
 		}
+
+		// Test default parse as well
+		for (Duration duration : TEST_VALUES.values())
+		{
+			assertEquals(TimeUtil.parseDuration(duration.toString()), duration);
+		}
 	}
 
 	@Test(expected = IllegalStateException.class)

--- a/src/test/java/com/github/lordrex34/config/TestTimeUtil.java
+++ b/src/test/java/com/github/lordrex34/config/TestTimeUtil.java
@@ -119,13 +119,15 @@ public class TestTimeUtil extends AbstractConfigTest
 			final Duration result = TimeUtil.parseDuration(pattern);
 			final Duration expectedResult = entry.getValue();
 
-			assertEquals("Failed to parse " + pattern, result, expectedResult);
+			assertEquals("Failed to parse " + pattern, expectedResult, result);
+
+			assertEquals("Failed reusing duration converted to string " + pattern, expectedResult, TimeUtil.parseDuration(TimeUtil.durationToString(expectedResult)));
 		}
 
 		// Test default parse as well
 		for (Duration duration : TEST_VALUES.values())
 		{
-			assertEquals(TimeUtil.parseDuration(duration.toString()), duration);
+			assertEquals(duration, TimeUtil.parseDuration(duration.toString()));
 		}
 	}
 


### PR DESCRIPTION
 * Added parsing for milliseconds, microseconds, nanoseconds and half-days.
 * Added "second/seconds", "minute/minutes" type names.
 * Adding support for parsing multiple chrono unit types, for example this pattern can be parsed now "10hours20mins30secs500millis200micros100nanos"
 * Removed months and years from the parsing because they are estimated values and not exact ones (read javadoc).
 * Removed defaulting to ChronoUnit enum type because it results in unsupported units for duration (duration does not accept estimate values).
 * Removed findIndexOfNonDigit since its no longer needed. If someone was using that, too bad, such thing shouldn't exist in TimeUtil at all, since its not time-related.
 * Added support for default parsing of duration as well.
 * Added durationToString method that does the reverse of parseDuration.
 * DurationConfigConverter updated to use durationToString when parsing back the duration to string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lordrex34/commons-annotation-config/23)
<!-- Reviewable:end -->
